### PR TITLE
サポートする拡張子に .fswiki を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
                 "id": "fsw",
                 "aliases": [
                     "FreeStyleWiki",
-                    "fsw"
+                    "fsw",
+                    "fswiki"
                 ],
                 "extensions": [
-                    ".fsw"
+                    ".fsw",
+                    ".fswiki"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
Closes: #2 

`.fswiki` をサポートする拡張子に追加しました。