### PR TITLE
シンタックスハイライトを Markdown に寄せる形で修正

### DIFF
--- a/syntaxes/fsw.tmLanguage.json
+++ b/syntaxes/fsw.tmLanguage.json
@@ -12,10 +12,7 @@
 			"include": "#list"
 		},
 		{
-			"include": "#code-begin"
-		},
-		{
-			"include": "#code-end"
+			"include": "#code_block"
 		},
 		{
 			"include": "#inline"
@@ -23,24 +20,86 @@
 	],
 	"repository": {
 		"heading": {
-			"name": "markup.heading.fsw",
-			"match": "(?:^|\\G)!{1,3}.+$"
+			"name": "markup.heading.markdown.fsw",
+			"match": "(?:^|\\G)(!{1,3}(.+))$",
+			"captures": {
+				"1": {
+					"patterns": [
+						{
+							"match": "(!{3})(.+)",
+							"name": "heading.1.fsw",
+							"captures": {
+								"1": {
+									"name": "punctuation.definition.heading.markdown.fsw"
+								},
+								"2": {
+									"name": "entity.name.section.fsw"
+								}
+							}
+						},
+						{
+							"match": "(!{2})(.+)",
+							"name": "heading.2.fsw",
+							"captures": {
+								"1": {
+									"name": "punctuation.definition.heading.markdown.fsw"
+								},
+								"2": {
+									"name": "entity.name.section.fsw"
+								}
+							}
+						},
+						{
+							"match": "(!{1})(.+)",
+							"name": "heading.3.fsw",
+							"captures": {
+								"1": {
+									"name": "punctuation.definition.heading.markdown.fsw"
+								},
+								"2": {
+									"name": "entity.name.section.fsw"
+								}
+							}
+						}
+					]
+				}
+			}
 		},
 		"quote": {
-			"name": "markup.quote.fsw",
-			"match": "(?:^|\\G)\"{2}.+$"
+			"name": "markup.quote.markdown.fsw",
+			"match": "(?:^|\\G)(\"{2})(.+)$",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.quote.begin.markdown.fsw"
+				}
+			}
 		},
 		"list": {
 			"name": "markup.list.fsw",
-			"match": "(?:^|\\G)[\\*\\+]{1,3}[^\\*\\+].+$"
+			"match": "(?:^|\\G)([\\*\\+]{1,3})([^\\*\\+].+)$",
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.list.begin.markdown.fsw"
+				},
+				"2": {
+					"name": "markup.list.unnumbered.markdown.fsw"
+				}
+			}
 		},
-		"code-begin": {
-			"name": "markup.quote.fsw",
-			"match": "(?:^|\\G)[{]{2}pre$"
-		},
-		"code-end": {
-			"name": "markup.quote.fsw",
-			"match": "(?:^|\\G)[}]{2}$"
+		"code_block": {
+			"name": "markup.fenced_code.block.markdown.fsw",
+			"begin": "(?:^|\\G)([{]{2}pre)$",
+			"beginCaptures": {
+				"1": {
+					"name": "entity.name.tag.fsw" 
+				}
+			},
+			"end": "(?:^|\\G)([}]{2})$",
+			"endCaptures": {
+				"1": {
+					"name": "entity.name.tag.fsw" 
+				}
+			}
 		},
 		"inline": {
 			"patterns": [
@@ -59,11 +118,11 @@
 			],
 			"repository": {
 				"bold": {
-					"name": "markup.bold.fsw",
+					"name": "markup.bold.markdown.fsw",
 					"match": "'''[^']+'''"
 				},
 				"italic": {
-					"name": "markup.italic.fsw",
+					"name": "markup.italic.markdown.fsw",
 					"match": "''[^']+''"
 				},
 				"strike": {


### PR DESCRIPTION
fixes #13 

Markdown の `.tmLanguage.json` を見て、修正しました。